### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ansi_up",
-  "version": "4.0.3",
+  "version": "4.0.4-lineaje-01",
   "description": "Convert ansi sequences in strings to colorful HTML",
   "keywords": [
     "ansi",
@@ -8,11 +8,17 @@
   ],
   "author": "drudru <drudru@gmail.com>",
   "license": "MIT",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "main": "./ansi_up.js",
   "types": "./dist/ansi_up.d.ts",
   "repository": {
     "type": "git",
-    "url": "git://github.com/drudru/ansi_up.git"
+    "url": "https://github.com/lineaje-labs-gos/ansi_up"
   },
   "bugs": {
     "url": "http://github.com/drudru/ansi_up/issues"


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
